### PR TITLE
Make VMM PML4Array included in kernel

### DIFF
--- a/kernel/libc/stdlib/memory/vmm.c
+++ b/kernel/libc/stdlib/memory/vmm.c
@@ -8,7 +8,7 @@ struct Level4Group {
     PML4E entries[512];
 };
 
-struct Level4Group *PML4Array;
+struct Level4Group PML4Array;
 
 void *get_physaddr(uint64_t vaddr) {
     const uint16_t offset = (uint16_t)((vaddr & 0x000000000FFF) >> 0);
@@ -17,7 +17,7 @@ void *get_physaddr(uint64_t vaddr) {
     const uint16_t PDP_i = (uint16_t)((vaddr & 0x007FC0000000) >> 30);
     const uint16_t PML4_i = (uint16_t)((vaddr & 0xFF8000000000) >> 39);
 
-    PML4E PML4 = PML4Array->entries[PML4_i];
+    PML4E PML4 = PML4Array.entries[PML4_i];
     if(PML4.Present == 0)
         return NULL;
 
@@ -48,7 +48,7 @@ void _x86_64_vmm_map(uint64_t vaddr, uint64_t paddr, uint32_t flags) {
     ok("Vaddr: 0x%.16llx, Paddr: 0x%.16llx, Flags: 0x%.8llx", vaddr, paddr,
        flags);
 
-    PML4E PML4 = PML4Array->entries[PML4_i];
+    PML4E PML4 = PML4Array.entries[PML4_i];
     if(PML4.Present == 0) {
         uint64_t temp = ((uint64_t)((flags & 0x0FFF) |
                                     ((uint64_t)(flags & 0x07FF0000) << 36)));
@@ -57,12 +57,12 @@ void _x86_64_vmm_map(uint64_t vaddr, uint64_t paddr, uint32_t flags) {
         PML4.Address = (uint64_t)pmm_request_page() >> 12;
         memset((void *)PHYS_TO_VIRT(PML4.Address << 12), 0, 4096);
 
-        PML4Array->entries[PML4_i] = PML4;
+        PML4Array.entries[PML4_i] = PML4;
     } else {
         uint64_t temp = *(uint64_t *)(&PML4);
         temp |= flags & 0xFFF;
         temp |= (uint64_t)(flags & 0x7FF0000) << 36;
-        PML4Array->entries[PML4_i] = *(PML4E *)&temp;
+        PML4Array.entries[PML4_i] = *(PML4E *)&temp;
     }
 
     ok("PML4 Addr: 0x%.16llx", PML4.Address);
@@ -131,11 +131,7 @@ void vmm_map_range(void *virt, void *phys, void *virt_end, uint32_t perms) {
 }
 
 void init_vmm() {
-    PML4Array = (struct Level4Group *)kmalloc(sizeof(struct Level4Group));
-    if(PML4Array == NULL) {
-        fail("Failed to allocate memory for PML4 array");
-        hcf();
-    }
+    memset(&PML4Array, 0, sizeof(PML4Array));
 
     vok("Kernel Physical Address: 0x%lX", kernel_addr_response->physical_base);
     vok("Kernel Virtual Address: 0x%lx", kernel_addr_response->virtual_base);


### PR DESCRIPTION
This is instead of it being allocated at runtime.