### PR TITLE
Fix pmm_request_page so it actually works.

### DIFF
--- a/kernel/libc/stdlib/memory/pmm.c
+++ b/kernel/libc/stdlib/memory/pmm.c
@@ -103,6 +103,7 @@ void *pmm_request_page() {
     while(1) {
         last_bit_val = bitmap_get(bitmap, last_allocated_index);
         if(last_bit_val == 0) {
+            bitmap_set(bitmap, last_allocated_index);
             return (void *)(last_allocated_index * PAGE_SIZE);
         } else {
             if(last_allocated_index >= bitmap_pages) {


### PR DESCRIPTION
Previously, the bitmap was not being updated after a singular page was being allocated, causing the same page to be allocated multiple times in a row. This is now fixed.